### PR TITLE
Remove RSVP links from site

### DIFF
--- a/src/themes/agency/layouts/partials/hero.html
+++ b/src/themes/agency/layouts/partials/hero.html
@@ -4,8 +4,8 @@
         <div class="intro-text">
             <div class="intro-lead-in">{{ with .Site.Params.hero.title }}{{ . | markdownify }}{{ end }}</div>
             <div class="intro-heading">{{ with .Site.Params.hero.subtitle }}{{ . | markdownify }}{{ end }}</div>
-            <a href="http://judiandmartywedding.rsvpify.com/" class="page-scroll btn btn-xl header-button">RSVP Now!</a>
-            <div class="big header-block">- OR -</div>
+            <!-- <a href="http://judiandmartywedding.rsvpify.com/" class="page-scroll btn btn-xl header-button">RSVP Now!</a>
+            <div class="big header-block">- OR -</div> -->
             <a href="#wedding-details" class="page-scroll btn btn-xl header-button">{{ with .Site.Params.hero.buttonText }}{{ . | markdownify }}{{ end }}</a>
         </div>
     </div>

--- a/src/themes/agency/layouts/partials/nav.html
+++ b/src/themes/agency/layouts/partials/nav.html
@@ -65,9 +65,9 @@
                     <a class="page-scroll" href="#contact">{{ with .Site.Params.navigation.contact }}{{ . | markdownify }}{{ end }}</a>
                 </li>
                 {{ end }} -->
-                <li>
+                <!-- <li>
                     <a class="page-top-nav" href="http://judiandmartywedding.rsvpify.com/">RSVP!</a>
-                </li>
+                </li> -->
                 {{ range .Site.Menus.postpend }}
                 <li>
                     <a class="page-top-nav" href="{{ .URL }}">{{ .Name | markdownify }}</a>


### PR DESCRIPTION
Judi/Marty ended up going with a service called greenvelop for their invitations and RSVPs. That service is done through email, giving each guest their own dedicated RSVP link. That pretty much eliminates any need for either RSVPify or any RSVP links on the site, so I removed all that.